### PR TITLE
FastAPI Requirement updated

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,22 @@
+name: Publish Artifact
+
+on:
+  push:
+    branches: [ master ]
+    tags: [ 'v*.*.*' ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      
+      - name: Install Poetry
+        run: |
+          pip3 install poetry

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [ master ]
     tags: [ 'v*.*.*' ]
-  pull_request:
-    branches: [ features/dependency-update ]
+  #pull_request:
+  #  branches: [ features/dependency-update ]
     
 jobs:
   build:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,14 +4,15 @@ on:
   push:
     branches: [ master ]
     tags: [ 'v*.*.*' ]
-
+  pull_request:
+    branches: [ features/dependency-update ]
+    
 jobs:
   build:
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
@@ -20,3 +21,15 @@ jobs:
       - name: Install Poetry
         run: |
           pip3 install poetry
+
+      - name: Poetry - Install
+        run: |
+          poetry install
+
+      - name: Poetry - build
+        run: |
+          poetry build
+        
+      #- name: Poetry - Publish
+      #  run: |
+      #    poetry publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi_healthcheck"
-version = "0.2.3"
+version = "0.2.4"
 description = "Base package to handle health checks with FastAPI."
 authors = ["James Tombleson <luther38@gmail.com>"]
 readme = "README.md"
@@ -12,7 +12,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-fastapi = "^0.70.0"
+fastapi = "^0.70"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
The new change should let the package be installed with FastAPI as long as it does not reach 1.0.0.  Once it reached 1.0.0 the package might need updates to support any changes.