### PR TITLE
Since fastapi has a strict dependency on starlette, this can be removed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.9"
 fastapi = "^0.82.0"
-starlette = "^0.19.1"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
- Fix for: starlette<0.20.0,>=0.19.1 (from fastapi-healthcheck==0.2.8)