### PR TITLE
Add better documentation for OpenAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Here is what you need to get started.
 ```python
 from fastapi import FastAPI
 from fastapi_healthcheck import HealthCheckFactory, healthCheckRoute
+from fastapi_healthcheck.model import HealthCheckModel
 from fastapi_healthcheck_sqlalchemy import HealthCheckSQLAlchemy
 
 app = FastAPI()
@@ -28,7 +29,7 @@ _healthChecks.add(HealthCheckSQLAlchemy(alias='postgres db', connectionUri=cs.va
 # This will check external URI and validate the response that is returned.
 # fastapi-healthcheck-uri
 _healthChecks.add(HealthCheckUri(alias='reddit', connectionUri="https://www.reddit.com/r/aww.json", tags=('external', 'reddit', 'aww')))
-app.add_api_route('/health', endpoint=healthCheckRoute(factory=_healthChecks))
+app.add_api_route('/health', endpoint=healthCheckRoute(factory=_healthChecks), response_model=HealthCheckModel)
 
 ```
 

--- a/fastapi_healthcheck/enum.py
+++ b/fastapi_healthcheck/enum.py
@@ -2,5 +2,5 @@ from enum import Enum
 
 
 class HealthCheckStatusEnum(Enum):
-    HEALTHY = "Healthy"
-    UNHEALTHY = "Unhealthy"
+    HEALTHY = "healthy"
+    UNHEALTHY = "unhealthy"

--- a/fastapi_healthcheck/route.py
+++ b/fastapi_healthcheck/route.py
@@ -11,14 +11,16 @@ def healthCheckRoute(factory: HealthCheckFactory) -> Callable:
     When called, the endpoint method within, will be called and it will run the job bound to the factory.
     The results will be parsed and sent back to the requestor via JSON.
     """
-    
+
     _factory = factory
 
     def endpoint() -> JSONResponse:
-        res = _factory.check()    
-        if res['status'] == HealthCheckStatusEnum.UNHEALTHY.value:
-            return JSONResponse(content=res, status_code=500)
-        return JSONResponse(content=res, status_code=200)
+        """
+        Check health of API and associated services.
+        """
+        res = _factory.check()
+        code = 500 if res["status"] == HealthCheckStatusEnum.UNHEALTHY.value else 200
+        return JSONResponse(content=res, status_code=code)
 
     return endpoint
 


### PR DESCRIPTION
This updates the handler with a brief docstring, and adds a response model for the autogenerated OpenAPI documentation by FastAPI.

I also updated the values of the enum to have a consistent case; it's more likely to mistype `Healthy` rather than either `HEALTHY` or `healthy`. 