### PR TITLE
Enable empty tags in JSON responses

### DIFF
--- a/fastapi_healthcheck/model.py
+++ b/fastapi_healthcheck/model.py
@@ -9,7 +9,7 @@ class HealthCheckEntityModel(BaseModel):
     alias: str
     status: Union[HealthCheckStatusEnum, str] = HealthCheckStatusEnum.HEALTHY
     timeTaken: Union[Optional[datetime], str] = ""
-    tags: List[str] = list()
+    tags: Optional[List[str]] = list()
 
 
 class HealthCheckModel(BaseModel):

--- a/fastapi_healthcheck/service.py
+++ b/fastapi_healthcheck/service.py
@@ -52,9 +52,9 @@ class HealthCheckFactory:
         for i in self._healthItems:
             # Generate the model
             if not hasattr(i, "_tags"):
-                i._tags = list()
+                i._tags = None
             item = HealthCheckEntityModel(
-                alias=i._alias, tags=i._tags if i._tags else []
+                alias=i._alias, tags=i._tags
             )
 
             # Track how long the entity took to respond


### PR DESCRIPTION
Tags are optional in the checks themselves, but currently they are enforced in the response and so you end up with a lot of empty lists for no reason :) This PR just removes that and leaves them as optional in the response too!